### PR TITLE
JSON value only Writer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,13 +91,17 @@ distributions {
 dependencies {
     compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
+    compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
 
     implementation "org.slf4j:slf4j-api:1.7.25"
     implementation "com.google.guava:guava:28.2-jre"
 
     implementation "org.apache.commons:commons-text:1.8"
 
+    testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
+    testImplementation "org.apache.kafka:connect-json:$kafkaVersion"
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.4"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 }
 

--- a/src/main/java/io/aiven/kafka/connect/common/grouper/RecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/common/grouper/RecordGrouper.java
@@ -27,6 +27,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 public interface RecordGrouper {
     /**
      * Associate the record with the appropriate file.
+     * @param record - record to group
      */
     void put(SinkRecord record);
 
@@ -37,6 +38,7 @@ public interface RecordGrouper {
 
     /**
      * Get all records associated with files, grouped by the file name.
+     * @return map of records assotiated with files
      */
     Map<String, List<SinkRecord>> records();
 

--- a/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
@@ -58,6 +58,7 @@ public final class TopicPartitionRecordGrouper implements RecordGrouper {
      *
      * @param filenameTemplate  the filename template.
      * @param maxRecordsPerFile the maximum number of records per file ({@code null} for unlimited).
+     * @param tsSource timestamp sources
      */
     public TopicPartitionRecordGrouper(final Template filenameTemplate,
                                        final Integer maxRecordsPerFile,

--- a/src/main/java/io/aiven/kafka/connect/common/output/JsonOutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/JsonOutputWriter.java
@@ -1,0 +1,55 @@
+package io.aiven.kafka.connect.common.output;
+
+import io.aiven.kafka.connect.common.config.OutputField;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class JsonOutputWriter implements OutputWriter {
+
+    private static final byte[] BATCH_START = "[".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] BATCH_END = "]".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] FIELD_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] RECORD_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
+
+    private final List<OutputFieldWriter> writers;
+
+    JsonOutputWriter(final List<OutputFieldWriter> writers) {
+        this.writers = writers;
+    }
+
+    public void startRecording(final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+        outputStream.write(BATCH_START);
+    }
+
+    public void writeRecord(final SinkRecord record,
+                            final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+        writeFields(record, outputStream);
+        outputStream.write(RECORD_SEPARATOR);
+    }
+
+    public void writeLastRecord(final SinkRecord record,
+                                final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+        writeFields(record, outputStream);
+        outputStream.write(BATCH_END);
+    }
+
+    private void writeFields(final SinkRecord record,
+                             final OutputStream outputStream) throws IOException {
+        final Iterator<OutputFieldWriter> writerIter = writers.iterator();
+        writerIter.next().write(record, outputStream);
+        while (writerIter.hasNext()) {
+            outputStream.write(FIELD_SEPARATOR);
+            writerIter.next().write(record, outputStream);
+        }
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/JsonValueWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/JsonValueWriter.java
@@ -1,0 +1,43 @@
+package io.aiven.kafka.connect.common.output;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.json.JsonConverter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Objects;
+
+public class JsonValueWriter implements OutputFieldWriter {
+
+    /**
+     * Takes the {@link SinkRecord}'s value as a JSON.
+     *
+     * @param record        the record to get the value from
+     * @param outputStream  the stream to write to
+     * @throws DataException when the value is not actually a JSON
+     */
+
+    private final JsonConverter converter;
+
+    public JsonValueWriter() {
+        converter = new JsonConverter();
+        // TODO: make a more generic configuration
+        converter.configure(Map.of("schemas.enable", false, "converter.type", "value"));
+    }
+
+    @Override
+    public void write(SinkRecord record, OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(record.valueSchema(), "value schema cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+        // Do not use Byte value???
+
+        if (record.value() == null) {
+            return;
+        }
+        byte[] bValue = converter.fromConnectData(record.topic(), record.valueSchema(), record.value());
+        outputStream.write(bValue);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
@@ -1,125 +1,15 @@
-/*
- * Copyright 2020 Aiven Oy
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.aiven.kafka.connect.common.output;
+
+import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
 
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.sink.SinkRecord;
+public interface OutputWriter {
 
-import io.aiven.kafka.connect.common.config.OutputField;
+    void writeLastRecord(final SinkRecord record,
+                         final OutputStream outputStream) throws IOException;
 
-public final class OutputWriter {
-
-    private static final byte[] FIELD_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] RECORD_SEPARATOR = "\n".getBytes(StandardCharsets.UTF_8);
-
-    private final List<OutputFieldWriter> writers;
-
-    private OutputWriter(final List<OutputFieldWriter> writers) {
-        this.writers = writers;
-    }
-
-    public void writeRecord(final SinkRecord record,
-                            final OutputStream outputStream) throws IOException {
-        Objects.requireNonNull(record, "record cannot be null");
-        Objects.requireNonNull(outputStream, "outputStream cannot be null");
-        writeFields(record, outputStream);
-        outputStream.write(RECORD_SEPARATOR);
-    }
-
-    public void writeLastRecord(final SinkRecord record,
-                                final OutputStream outputStream) throws IOException {
-        Objects.requireNonNull(record, "record cannot be null");
-        Objects.requireNonNull(outputStream, "outputStream cannot be null");
-        writeFields(record, outputStream);
-    }
-
-    private void writeFields(final SinkRecord record,
-                             final OutputStream outputStream) throws IOException {
-        final Iterator<OutputFieldWriter> writerIter = writers.iterator();
-        writerIter.next().write(record, outputStream);
-        while (writerIter.hasNext()) {
-            outputStream.write(FIELD_SEPARATOR);
-            writerIter.next().write(record, outputStream);
-        }
-    }
-
-    public static final class Builder {
-        private final List<OutputFieldWriter> writers = new ArrayList<>();
-
-        public final Builder addFields(final Collection<OutputField> fields) {
-            Objects.requireNonNull(fields, "fields cannot be null");
-
-            for (final OutputField field : fields) {
-                switch (field.getFieldType()) {
-                    case KEY:
-                        writers.add(new KeyWriter());
-                        break;
-
-                    case VALUE:
-                        switch (field.getEncodingType()) {
-                            case NONE:
-                                writers.add(new PlainValueWriter());
-                                break;
-
-                            case BASE64:
-                                writers.add(new Base64ValueWriter());
-                                break;
-
-                            default:
-                                throw new ConnectException("Unknown output field encoding type "
-                                    + field.getEncodingType());
-                        }
-                        break;
-
-                    case OFFSET:
-                        writers.add(new OffsetWriter());
-                        break;
-
-                    case TIMESTAMP:
-                        writers.add(new TimestampWriter());
-                        break;
-
-                    case HEADERS:
-                        writers.add(new HeadersWriter());
-                        break;
-
-                    default:
-                        throw new ConnectException("Unknown output field type " + field);
-                }
-            }
-
-            return this;
-        }
-
-        public final OutputWriter build() {
-            return new OutputWriter(writers);
-        }
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
+    void writeRecord(final SinkRecord record,
+                     final OutputStream outputStream) throws IOException;
 }

--- a/src/main/java/io/aiven/kafka/connect/common/output/PlainOutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/PlainOutputWriter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.config.OutputField;
+
+public final class PlainOutputWriter implements OutputWriter {
+
+    private static final byte[] FIELD_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] RECORD_SEPARATOR = "\n".getBytes(StandardCharsets.UTF_8);
+
+    private final List<OutputFieldWriter> writers;
+
+    private PlainOutputWriter(final List<OutputFieldWriter> writers) {
+        this.writers = writers;
+    }
+
+    public void writeRecord(final SinkRecord record,
+                            final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+        writeFields(record, outputStream);
+        outputStream.write(RECORD_SEPARATOR);
+    }
+
+    public void writeLastRecord(final SinkRecord record,
+                                final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+        writeFields(record, outputStream);
+    }
+
+    private void writeFields(final SinkRecord record,
+                             final OutputStream outputStream) throws IOException {
+        final Iterator<OutputFieldWriter> writerIter = writers.iterator();
+        writerIter.next().write(record, outputStream);
+        while (writerIter.hasNext()) {
+            outputStream.write(FIELD_SEPARATOR);
+            writerIter.next().write(record, outputStream);
+        }
+    }
+
+    public static final class Builder {
+        private final List<OutputFieldWriter> writers = new ArrayList<>();
+
+        public final Builder addFields(final Collection<OutputField> fields) {
+            Objects.requireNonNull(fields, "fields cannot be null");
+
+            for (final OutputField field : fields) {
+                switch (field.getFieldType()) {
+                    case KEY:
+                        writers.add(new KeyWriter());
+                        break;
+
+                    case VALUE:
+                        switch (field.getEncodingType()) {
+                            case NONE:
+                                writers.add(new PlainValueWriter());
+                                break;
+
+                            case BASE64:
+                                writers.add(new Base64ValueWriter());
+                                break;
+
+                            default:
+                                throw new ConnectException("Unknown output field encoding type "
+                                    + field.getEncodingType());
+                        }
+                        break;
+
+                    case OFFSET:
+                        writers.add(new OffsetWriter());
+                        break;
+
+                    case TIMESTAMP:
+                        writers.add(new TimestampWriter());
+                        break;
+
+                    case HEADERS:
+                        writers.add(new HeadersWriter());
+                        break;
+
+                    default:
+                        throw new ConnectException("Unknown output field type " + field);
+                }
+            }
+
+            return this;
+        }
+
+        public final PlainOutputWriter build() {
+            return new PlainOutputWriter(writers);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/common/output/JsonOutputWriterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/JsonOutputWriterTest.java
@@ -1,0 +1,112 @@
+package io.aiven.kafka.connect.common.output;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class JsonOutputWriterTest {
+
+    private static final List<OutputFieldWriter> writers = new ArrayList<>();
+    private static final JsonOutputWriter sut = new JsonOutputWriter(writers);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private ByteArrayOutputStream byteStream;
+
+    @BeforeAll
+    static void setUpAll() {
+        writers.add(new JsonValueWriter());
+    }
+
+    @BeforeEach
+    void setUp() {
+        byteStream = new ByteArrayOutputStream();
+    }
+
+    @Test
+    void flatOneStringJsonValue() {
+        SinkRecord record = createRecord("key0", Schema.STRING_SCHEMA, "value0", 1, 1000L);
+        assertRecords(Arrays.asList(record), "[\"value0\"]");
+    }
+
+    @Test
+    void flatManyStringsJsonValue() {
+        SinkRecord record1 = createRecord("key0", Schema.STRING_SCHEMA, "value0", 1, 1000L);
+        SinkRecord record2 = createRecord("key1", Schema.STRING_SCHEMA, "value1", 2, 1001L);
+
+        assertRecords(Arrays.asList(record1, record2), "[\"value0\",\"value1\"]");
+    }
+
+    @Test
+    void structManyJsonValue() {
+        Schema level2Schema = SchemaBuilder.struct().field("city", Schema.STRING_SCHEMA);
+        Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA)
+                                                    .field("address", level2Schema);
+
+        Struct struct1 = new Struct(level1Schema).put("name", "John")
+                                                 .put("address", new Struct(level2Schema).put("city", "Toronto"));
+        Struct struct2 = new Struct(level1Schema).put("name", "Pekka")
+                                                 .put("address", new Struct(level2Schema).put("city", "Helsinki"));
+
+        SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+        SinkRecord record2 = createRecord("key1", level1Schema, struct2, 2, 1001L);
+
+        String expected = "[{\"name\":\"John\",\"address\":{\"city\":\"Toronto\"}},{\"name\":\"Pekka\",\"address\":{\"city\":\"Helsinki\"}}]";
+        assertRecords(Arrays.asList(record1, record2), expected);
+    }
+
+    private SinkRecord createRecord(String key,
+                                    Schema valueSchema,
+                                    Object value,
+                                    int offset,
+                                    long timestamp
+                                    ) {
+        return new SinkRecord(
+                "anyTopic",
+                0,
+                Schema.STRING_SCHEMA,
+                key,
+                valueSchema,
+                value,
+                offset,
+                timestamp,
+                TimestampType.CREATE_TIME);
+    }
+
+    private void assertRecords(List<SinkRecord> records, String expected) {
+        try {
+            sut.startRecording(byteStream);
+            for (int i = 0; i < records.size() - 1; i++) {
+                sut.writeRecord(records.get(i), byteStream);
+            }
+            sut.writeLastRecord(records.get(records.size() - 1), byteStream);
+            assertEquals(expected, parse(byteStream.toByteArray()).toString());
+        } catch (final Exception e) {
+            fail();
+        }
+    }
+
+    private JsonNode parse(byte[] json) {
+        try {
+            return objectMapper.readTree(json);
+        } catch (IOException e) {
+            fail("IOException during JSON parse: " + e.getMessage());
+            throw new RuntimeException("failed");
+        }
+    }
+}


### PR DESCRIPTION
__WHY__:

To Support JSON Formatter for GCS and S3. [Story](https://app.clubhouse.io/aiven/story/10676/support-json-formatter-for-aiven-s3-and-gcs-connector)

__WHAT__:

- Step 1

Right now it is only possible to create 'Plain' output writer that limit values to Bytes only. Creating More general Interface OutputWriter so  any Implementation (PlainOutputWriters or JSONOutputWrites ) could be used in Sink classes.

- Step 2 [In progress]
Support simple (value only) and complex (values, key, timestamp) output as a valid JSON objects.

- Step 3 [Not started]
Support different configurations (e.g with or without schema) for JSONValueWriter