### PR TITLE
Refactor Plain output Writer

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/common/grouper/RecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/common/grouper/RecordGrouper.java
@@ -27,6 +27,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 public interface RecordGrouper {
     /**
      * Associate the record with the appropriate file.
+     * @param record - record to group
      */
     void put(SinkRecord record);
 
@@ -37,6 +38,7 @@ public interface RecordGrouper {
 
     /**
      * Get all records associated with files, grouped by the file name.
+     * @return map of records assotiated with files
      */
     Map<String, List<SinkRecord>> records();
 

--- a/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
+++ b/src/main/java/io/aiven/kafka/connect/common/grouper/TopicPartitionRecordGrouper.java
@@ -58,6 +58,7 @@ public final class TopicPartitionRecordGrouper implements RecordGrouper {
      *
      * @param filenameTemplate  the filename template.
      * @param maxRecordsPerFile the maximum number of records per file ({@code null} for unlimited).
+     * @param tsSource timestamp sources
      */
     public TopicPartitionRecordGrouper(final Template filenameTemplate,
                                        final Integer maxRecordsPerFile,

--- a/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
@@ -18,108 +18,14 @@ package io.aiven.kafka.connect.common.output;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
 
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-import io.aiven.kafka.connect.common.config.OutputField;
+public interface OutputWriter {
 
-public final class OutputWriter {
+    void writeLastRecord(final SinkRecord record,
+                         final OutputStream outputStream) throws IOException;
 
-    private static final byte[] FIELD_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] RECORD_SEPARATOR = "\n".getBytes(StandardCharsets.UTF_8);
-
-    private final List<OutputFieldWriter> writers;
-
-    private OutputWriter(final List<OutputFieldWriter> writers) {
-        this.writers = writers;
-    }
-
-    public void writeRecord(final SinkRecord record,
-                            final OutputStream outputStream) throws IOException {
-        Objects.requireNonNull(record, "record cannot be null");
-        Objects.requireNonNull(outputStream, "outputStream cannot be null");
-        writeFields(record, outputStream);
-        outputStream.write(RECORD_SEPARATOR);
-    }
-
-    public void writeLastRecord(final SinkRecord record,
-                                final OutputStream outputStream) throws IOException {
-        Objects.requireNonNull(record, "record cannot be null");
-        Objects.requireNonNull(outputStream, "outputStream cannot be null");
-        writeFields(record, outputStream);
-    }
-
-    private void writeFields(final SinkRecord record,
-                             final OutputStream outputStream) throws IOException {
-        final Iterator<OutputFieldWriter> writerIter = writers.iterator();
-        writerIter.next().write(record, outputStream);
-        while (writerIter.hasNext()) {
-            outputStream.write(FIELD_SEPARATOR);
-            writerIter.next().write(record, outputStream);
-        }
-    }
-
-    public static final class Builder {
-        private final List<OutputFieldWriter> writers = new ArrayList<>();
-
-        public final Builder addFields(final Collection<OutputField> fields) {
-            Objects.requireNonNull(fields, "fields cannot be null");
-
-            for (final OutputField field : fields) {
-                switch (field.getFieldType()) {
-                    case KEY:
-                        writers.add(new KeyWriter());
-                        break;
-
-                    case VALUE:
-                        switch (field.getEncodingType()) {
-                            case NONE:
-                                writers.add(new PlainValueWriter());
-                                break;
-
-                            case BASE64:
-                                writers.add(new Base64ValueWriter());
-                                break;
-
-                            default:
-                                throw new ConnectException("Unknown output field encoding type "
-                                    + field.getEncodingType());
-                        }
-                        break;
-
-                    case OFFSET:
-                        writers.add(new OffsetWriter());
-                        break;
-
-                    case TIMESTAMP:
-                        writers.add(new TimestampWriter());
-                        break;
-
-                    case HEADERS:
-                        writers.add(new HeadersWriter());
-                        break;
-
-                    default:
-                        throw new ConnectException("Unknown output field type " + field);
-                }
-            }
-
-            return this;
-        }
-
-        public final OutputWriter build() {
-            return new OutputWriter(writers);
-        }
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
+    void writeRecord(final SinkRecord record,
+                     final OutputStream outputStream) throws IOException;
 }

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/AbstractValuePlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/AbstractValuePlainWriter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.common.output;
+package io.aiven.kafka.connect.common.output.plainwriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -24,7 +24,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public abstract class AbstractValueWriter implements OutputFieldWriter {
+public abstract class AbstractValuePlainWriter implements OutputFieldPlainWriter {
     /**
      * Takes the {@link SinkRecord}'s value as a byte array.
      *

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/Base64ValuePlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/Base64ValuePlainWriter.java
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.common.output;
+package io.aiven.kafka.connect.common.output.plainwriter;
 
-public class PlainValueWriter extends AbstractValueWriter {
+import java.util.Base64;
+
+public class Base64ValuePlainWriter extends AbstractValuePlainWriter {
     @Override
     protected byte[] getOutputBytes(final byte[] value) {
-        return value;
+        return Base64.getEncoder().encode(value);
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/HeadersPlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/HeadersPlainWriter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.common.output;
+package io.aiven.kafka.connect.common.output.plainwriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -27,7 +27,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public class HeadersWriter implements OutputFieldWriter {
+public class HeadersPlainWriter implements OutputFieldPlainWriter {
     private static final byte[] HEADER_KEY_VALUE_SEPARATOR = ":".getBytes(StandardCharsets.UTF_8);
     private static final byte[] HEADERS_SEPARATOR = ";".getBytes(StandardCharsets.UTF_8);
     private final ByteArrayConverter byteArrayConverter = new ByteArrayConverter();

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/KeyPlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/KeyPlainWriter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.common.output;
+package io.aiven.kafka.connect.common.output.plainwriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,7 +25,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public final class KeyWriter implements OutputFieldWriter {
+public final class KeyPlainWriter implements OutputFieldPlainWriter {
     /**
      * Takes the {@link SinkRecord}'s key as a byte array.
      *

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/OffsetPlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/OffsetPlainWriter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.common.output;
+package io.aiven.kafka.connect.common.output.plainwriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public final class OffsetWriter implements OutputFieldWriter {
+public final class OffsetPlainWriter implements OutputFieldPlainWriter {
     @Override
     public void write(final SinkRecord record,
                       final OutputStream outputStream) throws IOException {

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/OutputFieldPlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/OutputFieldPlainWriter.java
@@ -14,24 +14,15 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.common.output;
+package io.aiven.kafka.connect.common.output.plainwriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public final class TimestampWriter implements OutputFieldWriter {
-    @Override
-    public void write(final SinkRecord record,
-                      final OutputStream outputStream) throws IOException {
-        Objects.requireNonNull(record, "record cannot be null");
-        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+public interface OutputFieldPlainWriter {
 
-        if (record.timestamp() != null) {
-            outputStream.write(record.timestamp().toString().getBytes(StandardCharsets.UTF_8));
-        }
-    }
+    void write(SinkRecord record, OutputStream outputStream) throws IOException;
+
 }

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/OutputPlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/OutputPlainWriter.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.plainwriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.config.OutputField;
+import io.aiven.kafka.connect.common.output.OutputWriter;
+
+public final class OutputPlainWriter implements OutputWriter {
+
+    private static final byte[] FIELD_SEPARATOR = ",".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] RECORD_SEPARATOR = "\n".getBytes(StandardCharsets.UTF_8);
+
+    private final List<OutputFieldPlainWriter> writers;
+
+    private OutputPlainWriter(final List<OutputFieldPlainWriter> writers) {
+        this.writers = writers;
+    }
+
+    public void writeRecord(final SinkRecord record,
+                            final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+        writeFields(record, outputStream);
+        outputStream.write(RECORD_SEPARATOR);
+    }
+
+    public void writeLastRecord(final SinkRecord record,
+                                final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+        writeFields(record, outputStream);
+    }
+
+    private void writeFields(final SinkRecord record,
+                             final OutputStream outputStream) throws IOException {
+        final Iterator<OutputFieldPlainWriter> writerIter = writers.iterator();
+        writerIter.next().write(record, outputStream);
+        while (writerIter.hasNext()) {
+            outputStream.write(FIELD_SEPARATOR);
+            writerIter.next().write(record, outputStream);
+        }
+    }
+
+    public static final class Builder {
+        private final List<OutputFieldPlainWriter> writers = new ArrayList<>();
+
+        public final Builder addFields(final Collection<OutputField> fields) {
+            Objects.requireNonNull(fields, "fields cannot be null");
+
+            for (final OutputField field : fields) {
+                switch (field.getFieldType()) {
+                    case KEY:
+                        writers.add(new KeyPlainWriter());
+                        break;
+
+                    case VALUE:
+                        switch (field.getEncodingType()) {
+                            case NONE:
+                                writers.add(new ValuePlainWriter());
+                                break;
+
+                            case BASE64:
+                                writers.add(new Base64ValuePlainWriter());
+                                break;
+
+                            default:
+                                throw new ConnectException("Unknown output field encoding type "
+                                    + field.getEncodingType());
+                        }
+                        break;
+
+                    case OFFSET:
+                        writers.add(new OffsetPlainWriter());
+                        break;
+
+                    case TIMESTAMP:
+                        writers.add(new TimestampPlainWriter());
+                        break;
+
+                    case HEADERS:
+                        writers.add(new HeadersPlainWriter());
+                        break;
+
+                    default:
+                        throw new ConnectException("Unknown output field type " + field);
+                }
+            }
+
+            return this;
+        }
+
+        public final OutputPlainWriter build() {
+            return new OutputPlainWriter(writers);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/TimestampPlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/TimestampPlainWriter.java
@@ -14,15 +14,24 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.common.output;
+package io.aiven.kafka.connect.common.output.plainwriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import org.apache.kafka.connect.sink.SinkRecord;
 
-public interface OutputFieldWriter {
+public final class TimestampPlainWriter implements OutputFieldPlainWriter {
+    @Override
+    public void write(final SinkRecord record,
+                      final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
 
-    void write(SinkRecord record, OutputStream outputStream) throws IOException;
-
+        if (record.timestamp() != null) {
+            outputStream.write(record.timestamp().toString().getBytes(StandardCharsets.UTF_8));
+        }
+    }
 }

--- a/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/ValuePlainWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/plainwriter/ValuePlainWriter.java
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-package io.aiven.kafka.connect.common.output;
+package io.aiven.kafka.connect.common.output.plainwriter;
 
-import java.util.Base64;
-
-public class Base64ValueWriter extends AbstractValueWriter {
+public class ValuePlainWriter extends AbstractValuePlainWriter {
     @Override
     protected byte[] getOutputBytes(final byte[] value) {
-        return Base64.getEncoder().encode(value);
+        return value;
     }
 }


### PR DESCRIPTION
__WHY__:

This is a first part of the ticket "To Support JSON Formatter for GCS and S3".

This one is a Refactoring PR. It doesn't include any new Feature changes, so it is easy to review.
It also will make a next PR review simpler.

__WHAT__:

All current Writers moved to a 'PlainWriter', because flat structure is hard-coded into this classes.
