### PR TITLE
Add json writers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,13 +91,17 @@ distributions {
 dependencies {
     compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
+    compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
 
     implementation "org.slf4j:slf4j-api:1.7.25"
     implementation "com.google.guava:guava:28.2-jre"
 
     implementation "org.apache.commons:commons-text:1.8"
 
+    testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
+    testImplementation "org.apache.kafka:connect-json:$kafkaVersion"
     testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.4"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 }
 

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/HeaderBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/HeaderBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+class HeaderBuilder implements OutputFieldBuilder {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final JsonConverter converter;
+
+    public HeaderBuilder() {
+        converter = new JsonConverter();
+        // TODO: make a more generic configuration
+        converter.configure(Map.of("schemas.enable", false, "converter.type", "header"));
+    }
+
+    @Override
+    public JsonNode build(final SinkRecord record) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+
+        final String topic = record.topic();
+
+        if (record.headers() == null) {
+            return null;
+        }
+
+        final ArrayNode root = JsonNodeFactory.instance.arrayNode();
+
+        for (final Header header : record.headers()) {
+            final ObjectNode headerRoot = JsonNodeFactory.instance.objectNode();
+            final String key = header.key();
+            headerRoot.put("key", key);
+            final JsonNode headerNode = nodeFromHeader(header, topic);
+            headerRoot.set("value", headerNode);
+            root.add(headerRoot);
+        }
+        return root;
+    }
+
+    private JsonNode nodeFromHeader(final Header header, final String topic) throws IOException {
+        return objectMapper.readTree(converter.fromConnectHeader(topic,
+                                                                 header.key(),
+                                                                 header.schema(),
+                                                                 header.value()));
+
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/JsonLinesOutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/JsonLinesOutputWriter.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.config.OutputField;
+import io.aiven.kafka.connect.common.config.OutputFieldType;
+import io.aiven.kafka.connect.common.output.OutputWriter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+
+public class JsonLinesOutputWriter implements OutputWriter {
+
+    private final Map<String, OutputFieldBuilder> fieldBuilders;
+    private static final byte[] RECORD_SEPARATOR = "\n".getBytes(StandardCharsets.UTF_8);
+    private final ObjectMapper objectMapper;
+
+    JsonLinesOutputWriter(final Map<String, OutputFieldBuilder> fieldBuilders) {
+
+        this.fieldBuilders = fieldBuilders;
+        this.objectMapper = new ObjectMapper();
+        objectMapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+    }
+
+    public void writeRecord(final SinkRecord record,
+                            final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+
+        outputStream.write(objectMapper.writeValueAsBytes(writeFields(record)));
+        outputStream.write(RECORD_SEPARATOR);
+    }
+
+    public void writeLastRecord(final SinkRecord record,
+                                final OutputStream outputStream) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        Objects.requireNonNull(outputStream, "outputStream cannot be null");
+
+        outputStream.write(objectMapper.writeValueAsBytes(writeFields(record)));
+    }
+
+    private JsonNode writeFields(final SinkRecord record) throws IOException {
+        final Iterator<Map.Entry<String, OutputFieldBuilder>> writerIter = fieldBuilders.entrySet().iterator();
+
+
+        final ObjectNode root = JsonNodeFactory.instance.objectNode();
+        while (writerIter.hasNext()) {
+            writeEntry(writerIter.next(), record, root);
+        }
+        return root;
+    }
+
+    private void writeEntry(final Map.Entry<String, OutputFieldBuilder> entry,
+                            final SinkRecord record,
+                            final ObjectNode root) throws IOException {
+        final JsonNode node = entry.getValue().build(record);
+        root.set(entry.getKey(), node);
+    }
+
+    public static final class Builder {
+        private final Map<String, OutputFieldBuilder> fieldBuilders = new HashMap<>();
+
+        public final JsonLinesOutputWriter.Builder addFields(final Collection<OutputField> fields) {
+            Objects.requireNonNull(fields, "fields cannot be null");
+
+            for (final OutputField field : fields) {
+                fieldBuilders.put(field.getFieldType().name, writerFromType(field.getFieldType()));
+            }
+
+            return this;
+        }
+
+        private OutputFieldBuilder writerFromType(final OutputFieldType fieldType) {
+            switch (fieldType) {
+                case KEY:
+                    return new KeyBuilder();
+
+                case VALUE:
+                    return new ValueBuilder();
+
+                case OFFSET:
+                    return new OffsetBuilder();
+
+                case TIMESTAMP:
+                    return new TimestampBuilder();
+
+                case HEADERS:
+                    return new HeaderBuilder();
+
+                default:
+                    throw new ConnectException("Unknown output field type " + fieldType);
+            }
+        }
+
+        public final JsonLinesOutputWriter build() {
+            return new JsonLinesOutputWriter(fieldBuilders);
+        }
+    }
+
+    public static JsonLinesOutputWriter.Builder builder() {
+        return new JsonLinesOutputWriter.Builder();
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/KeyBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/KeyBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class KeyBuilder implements OutputFieldBuilder {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final JsonConverter converter;
+
+    public KeyBuilder() {
+        converter = new JsonConverter();
+        // TODO: make a more generic configuration
+        converter.configure(Map.of("schemas.enable", false, "converter.type", "key"));
+    }
+
+    /**
+     * Takes the {@link SinkRecord}'s key as a JSON.
+     *
+     * <p>If the key is {@code null}, it outputs nothing.
+     *
+     * <p>If the key is not {@code null}, it assumes the key <b>is</b> a JSON
+     *
+     * @param record       the record to get the key from
+     * @throws DataException when the key is not convertible to Json
+     */
+    @Override
+    public JsonNode build(final SinkRecord record) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+        if (record.key() == null) {
+            return null;
+        }
+
+        return objectMapper.readTree(converter.fromConnectData(record.topic(), record.keySchema(), record.key()));
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/OffsetBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/OffsetBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+class OffsetBuilder implements OutputFieldBuilder {
+
+    @Override
+    public JsonNode build(final SinkRecord record) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+
+        return JsonNodeFactory.instance.numberNode(record.kafkaOffset());
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/OutputFieldBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/OutputFieldBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import java.io.IOException;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+
+interface OutputFieldBuilder {
+
+    JsonNode build(SinkRecord record) throws IOException;
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/TimestampBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/TimestampBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+
+class TimestampBuilder implements OutputFieldBuilder {
+
+    @Override
+    public JsonNode build(final SinkRecord record) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+
+        if (record.timestamp() == null) {
+            return null;
+        }
+        final Instant date = Instant.ofEpochMilli(record.timestamp());
+        final DateTimeFormatter formatter =  DateTimeFormatter.ISO_INSTANT;
+        final String timestampAsISO = formatter.format(date);
+
+        return JsonNodeFactory.instance.textNode(timestampAsISO);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/ValueBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/ValueBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ValueBuilder implements OutputFieldBuilder {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final JsonConverter converter;
+
+    public ValueBuilder() {
+        converter = new JsonConverter();
+        // TODO: make a more generic configuration
+        converter.configure(Map.of("schemas.enable", false, "converter.type", "value"));
+    }
+
+    /**
+     * Takes the {@link SinkRecord}'s value as a JSON.
+     *
+     * @param record        the record to get the value from
+     * @throws DataException when the value is not actually a JSON
+     * @return JsonNode     Value transformed to any JSON value
+     */
+    @Override
+    public JsonNode build(final SinkRecord record) throws IOException {
+        Objects.requireNonNull(record, "record cannot be null");
+
+        if (record.value() == null) {
+            return null;
+        }
+
+        return objectMapper.readTree(converter.fromConnectData(record.topic(),
+                                                               record.valueSchema(),
+                                                               record.value()));
+    }
+}

--- a/src/test/java/io/aiven/kafka/connect/common/output/JsonLinesOutputWriterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/JsonLinesOutputWriterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.output.jsonwriter.JsonLinesOutputWriter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class JsonLinesOutputWriterTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    protected ByteArrayOutputStream byteStream;
+    protected JsonLinesOutputWriter sut;
+
+    protected SinkRecord createRecord(final String key,
+                                      final Schema valueSchema,
+                                      final Object value,
+                                      final int offset,
+                                      final Long timestamp
+    ) {
+        return new SinkRecord(
+                "anyTopic",
+                0,
+                Schema.STRING_SCHEMA,
+                key,
+                valueSchema,
+                value,
+                offset,
+                timestamp,
+                TimestampType.CREATE_TIME);
+    }
+
+    protected void assertRecords(final List<SinkRecord> records, final String expected) throws IOException {
+        for (int i = 0; i < records.size() - 1; i++) {
+            sut.writeRecord(records.get(i), byteStream);
+        }
+        sut.writeLastRecord(records.get(records.size() - 1), byteStream);
+        assertEquals(expected, parseJsonLines(byteStream.toByteArray()));
+    }
+
+    // It also makes sure that bytes represents a valid JSONs lines with \n as Delimiter
+    protected String parseJsonLines(final byte[] json) throws IOException {
+        final Charset utf8 = StandardCharsets.UTF_8;
+        final ByteArrayInputStream stream = new ByteArrayInputStream(json);
+        final InputStreamReader streamReader = new InputStreamReader(stream, utf8);
+        final BufferedReader bufferedReader = new BufferedReader(streamReader);
+        final StringBuilder stringBuilder = new StringBuilder();
+
+        String jsonLine = bufferedReader.readLine();
+        while (jsonLine != null) {
+            stringBuilder.append(objectMapper.readTree(jsonLine.getBytes(utf8)).toString());
+            jsonLine = bufferedReader.readLine();
+            if (jsonLine != null) {
+                stringBuilder.append("\n");
+            }
+        }
+        return stringBuilder.toString();
+    }
+}
+

--- a/src/test/java/io/aiven/kafka/connect/common/output/WithMetadataJsonLinesOutputWriterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/WithMetadataJsonLinesOutputWriterTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.config.OutputField;
+import io.aiven.kafka.connect.common.config.OutputFieldEncodingType;
+import io.aiven.kafka.connect.common.config.OutputFieldType;
+import io.aiven.kafka.connect.common.output.jsonwriter.JsonLinesOutputWriter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+class WithMetadataJsonLinesOutputWriterTest extends JsonLinesOutputWriterTest {
+    private final OutputFieldEncodingType noEncoding = OutputFieldEncodingType.NONE;
+
+    @BeforeEach
+    void setUp() {
+
+        byteStream = new ByteArrayOutputStream();
+        sut = null;
+    }
+
+    @Test
+    void jsonValueWithoutMetadataAndValue() throws IOException {
+        final List<OutputField> fields = Arrays.asList();
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+
+        final String expected = "{}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+    @Test
+    void jsonValueWithValue() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+
+        final String expected = "{\"value\":{\"name\":\"John\"}}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+    @Test
+    void jsonValueWithOneFieldAndValue() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
+                new OutputField(OutputFieldType.KEY, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+
+        final String expected = "{\"value\":{\"name\":\"John\"},\"key\":\"key0\"}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+    @Test
+    void multiStringJsonValueWithOneFieldAndValue() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
+                new OutputField(OutputFieldType.KEY, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+        final Struct struct2 = new Struct(level1Schema).put("name", "Pekka");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+        final SinkRecord record2 = createRecord("key0", level1Schema, struct2, 1, 1000L);
+
+        final String expected = "{\"value\":{\"name\":\"John\"},\"key\":\"key0\"}\n"
+                              + "{\"value\":{\"name\":\"Pekka\"},\"key\":\"key0\"}";
+
+        assertRecords(Arrays.asList(record1, record2), expected);
+    }
+
+    @Test
+    void jsonValueWithAllMetadata() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
+                new OutputField(OutputFieldType.KEY, noEncoding),
+                new OutputField(OutputFieldType.OFFSET, noEncoding),
+                new OutputField(OutputFieldType.TIMESTAMP, noEncoding),
+                new OutputField(OutputFieldType.HEADERS, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+        record1.headers().add("headerKey", "headerValue", Schema.STRING_SCHEMA);
+
+        final String expected = "{\"headers\":[{\"key\":\"headerKey\",\"value\":\"headerValue\"}],"
+                + "\"offset\":1,"
+                + "\"value\":{\"name\":\"John\"},"
+                + "\"key\":\"key0\","
+                + "\"timestamp\":\"1970-01-01T00:00:01Z\"}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+    @Test
+    void jsonValueWithMultipleHeaders() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
+                new OutputField(OutputFieldType.HEADERS, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+        record1.headers().add("headerKey1", "headerValue1", Schema.STRING_SCHEMA);
+        record1.headers().add("headerKey2", "headerValue2", Schema.STRING_SCHEMA);
+
+        final String expected = "{\"headers\":"
+                + "[{\"key\":\"headerKey1\",\"value\":\"headerValue1\"},"
+                + "{\"key\":\"headerKey2\",\"value\":\"headerValue2\"}],"
+                                + "\"value\":{\"name\":\"John\"}}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+    @Test
+    void jsonValueWithMissingValue() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, null, 1, 1000L);
+
+        final String expected = "{\"value\":null}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+    @Test
+    void jsonValueWithMissingKey() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
+                new OutputField(OutputFieldType.KEY, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+
+        final SinkRecord record1 = createRecord(null, level1Schema, struct1, 1, 1000L);
+
+        final String expected = "{\"value\":{\"name\":\"John\"},\"key\":null}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+    @Test
+    void jsonValueWithMissingTimestamp() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
+                new OutputField(OutputFieldType.TIMESTAMP, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+
+        final SinkRecord record1 = createRecord(null, level1Schema, struct1, 1, null);
+
+        final String expected = "{\"value\":{\"name\":\"John\"},\"timestamp\":null}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+    @Test
+    void jsonValueWithMissingHeader() throws IOException {
+        final List<OutputField> fields = Arrays.asList(new OutputField(OutputFieldType.VALUE, noEncoding),
+                new OutputField(OutputFieldType.HEADERS, noEncoding));
+        sut = JsonLinesOutputWriter.builder().addFields(fields).build();
+        final Schema level1Schema = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA);
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+
+        final String expected = "{\"headers\":[],\"value\":{\"name\":\"John\"}}";
+
+        assertRecords(Collections.singletonList(record1), expected);
+    }
+
+}


### PR DESCRIPTION
__WHY__:

This PR related to "To Support JSON Formatter for GCS and S3" Story

This one add different Json Writers. It incudes all new classes required for writing Json

__WHAT__:

There are couple assumptions:
 - Currently result is presented not in a **Json** format, but in [**Jsonl**](https://jsonlines.org/) format. This came from assumption that this format is better for loading big chunks of Data. For this purpose was added **JsonLinesSerializer**. It is very simple to use a classic Json instead: it is just needed to use default kafka's **JsonSerializer**.
- I assumed that Json is needed as human readable format, so by default I selected to print timestamp as a **String**(not **Long**) and do not print an object schema for each Json object.