### PR TITLE
Support for saving the raw value with json writers

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
@@ -18,7 +18,10 @@ package io.aiven.kafka.connect.common.output;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import java.util.zip.GZIPOutputStream;
 
 import org.apache.kafka.connect.errors.ConnectException;

--- a/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
@@ -138,11 +138,11 @@ public abstract class OutputWriter implements AutoCloseable {
                     Objects.requireNonNull(outputFields, "Output fields haven't been set");
                     return new PlainOutputWriter(outputFields, getCompressedStream(out));
                 case JSONL:
-                    return outputFields == null
+                    return outputFields == null || outputFields.isEmpty()
                         ? new JsonLinesOutputWriter(getCompressedStream(out))
                         : new JsonLinesOutputWriter(outputFields, getCompressedStream(out));
                 case JSON:
-                    return outputFields == null
+                    return outputFields == null || outputFields.isEmpty()
                         ? new JsonOutputWriter(getCompressedStream(out))
                         : new JsonOutputWriter(outputFields, getCompressedStream(out));
                 case PARQUET:

--- a/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/OutputWriter.java
@@ -109,12 +109,8 @@ public abstract class OutputWriter implements AutoCloseable {
     public static class Builder {
 
         protected CompressionType compressionType;
-
         protected Map<String, String> externalProperties;
-
         protected Collection<OutputField> outputFields;
-
-        protected boolean unwrapValue = false;
 
         public Builder withCompressionType(final CompressionType compressionType) {
             if (Objects.isNull(compressionType)) {

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/JsonLinesOutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/JsonLinesOutputWriter.java
@@ -30,6 +30,10 @@ public class JsonLinesOutputWriter extends OutputWriter {
         super(outputStream, new Builder().addFields(fields).build());
     }
 
+    public JsonLinesOutputWriter(final OutputStream outputStream) {
+        super(outputStream, new PlainValueJsonLinesOutputStreamWriter());
+    }
+
     static final class Builder {
         private JsonOutputFieldComposer fieldsComposer = new JsonOutputFieldComposer();
 

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/JsonOutputWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/JsonOutputWriter.java
@@ -30,6 +30,10 @@ public class JsonOutputWriter extends OutputWriter {
         super(outputStream, new Builder().addFields(fields).build());
     }
 
+    public JsonOutputWriter(final OutputStream outputStream) {
+        super(outputStream, new PlainValueJsonOutputStreamWriter());
+    }
+
     static final class Builder {
         private final JsonOutputFieldComposer fieldsComposer = new JsonOutputFieldComposer();
 

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/PlainValueJsonLinesOutputStreamWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/PlainValueJsonLinesOutputStreamWriter.java
@@ -16,15 +16,16 @@
 
 package io.aiven.kafka.connect.common.output.jsonwriter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import io.aiven.kafka.connect.common.output.OutputStreamWriter;
-import org.apache.kafka.connect.sink.SinkRecord;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.output.OutputStreamWriter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 class PlainValueJsonLinesOutputStreamWriter implements OutputStreamWriter {
 

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/PlainValueJsonLinesOutputStreamWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/PlainValueJsonLinesOutputStreamWriter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.aiven.kafka.connect.common.output.OutputStreamWriter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+
+class PlainValueJsonLinesOutputStreamWriter implements OutputStreamWriter {
+
+    private static final byte[] RECORD_SEPARATOR = "\n".getBytes(StandardCharsets.UTF_8);
+    private final ObjectMapper objectMapper;
+    private final OutputFieldBuilder valueBuilder;
+
+    PlainValueJsonLinesOutputStreamWriter() {
+        this.objectMapper = new ObjectMapper();
+        this.valueBuilder = new ValueBuilder();
+        objectMapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+    }
+
+    @Override
+    public void writeRecordsSeparator(final OutputStream outputStream) throws IOException {
+        outputStream.write(RECORD_SEPARATOR);
+    }
+
+    @Override
+    public void writeOneRecord(final OutputStream outputStream, final SinkRecord record) throws IOException {
+        outputStream.write(objectMapper.writeValueAsBytes(valueBuilder.build(record)));
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/PlainValueJsonOutputStreamWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/PlainValueJsonOutputStreamWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.output.jsonwriter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.aiven.kafka.connect.common.output.OutputStreamWriter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+class PlainValueJsonOutputStreamWriter implements OutputStreamWriter {
+
+    private final ObjectMapper objectMapper;
+    private final OutputFieldBuilder valueBuilder;
+    private static final byte[] BATCH_START = "[\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] RECORD_SEPARATOR = ",\n".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] BATCH_END = "\n]".getBytes(StandardCharsets.UTF_8);
+
+    PlainValueJsonOutputStreamWriter() {
+        this.objectMapper = new ObjectMapper();
+        this.valueBuilder = new ValueBuilder();
+        objectMapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+    }
+
+    @Override
+    public void startWriting(final OutputStream outputStream) throws IOException {
+        outputStream.write(BATCH_START);
+    }
+
+    @Override
+    public void writeRecordsSeparator(final OutputStream outputStream) throws IOException {
+        outputStream.write(RECORD_SEPARATOR);
+    }
+
+    @Override
+    public void writeOneRecord(final OutputStream outputStream, final SinkRecord record) throws IOException {
+        outputStream.write(objectMapper.writeValueAsBytes(valueBuilder.build(record)));
+    }
+
+    @Override
+    public void stopWriting(final OutputStream outputStream) throws IOException {
+        outputStream.write(BATCH_END);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/PlainValueJsonOutputStreamWriter.java
+++ b/src/main/java/io/aiven/kafka/connect/common/output/jsonwriter/PlainValueJsonOutputStreamWriter.java
@@ -16,14 +16,16 @@
 
 package io.aiven.kafka.connect.common.output.jsonwriter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import io.aiven.kafka.connect.common.output.OutputStreamWriter;
-import org.apache.kafka.connect.sink.SinkRecord;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.output.OutputStreamWriter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 class PlainValueJsonOutputStreamWriter implements OutputStreamWriter {
 

--- a/src/test/java/io/aiven/kafka/connect/common/output/JsonLinesOutputWriterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/JsonLinesOutputWriterTest.java
@@ -228,6 +228,20 @@ class JsonLinesOutputWriterTest extends JsonOutputWriterTestHelper {
         assertEquals(expected, useWithWrongLastRecord(Arrays.asList(record1, record2)));
     }
 
+    @Test
+    void plainJsonValueWithValue() throws IOException {
+        sut = new JsonLinesOutputWriter(byteStream);
+
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+        final Struct struct2 = new Struct(level1Schema).put("name", "Pekka");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+        final SinkRecord record2 = createRecord("key0", level1Schema, struct2, 1, 1000L);
+
+        final String expected = "{\"name\":\"John\"}\n{\"name\":\"Pekka\"}";
+        assertEquals(expected, useWithWrongLastRecord(Arrays.asList(record1, record2)));
+    }
+
     protected String parseJson(final byte[] json) throws IOException {
         final Charset utf8 = StandardCharsets.UTF_8;
         final ByteArrayInputStream stream = new ByteArrayInputStream(json);

--- a/src/test/java/io/aiven/kafka/connect/common/output/JsonOutputWriterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/output/JsonOutputWriterTest.java
@@ -215,6 +215,19 @@ public class JsonOutputWriterTest extends JsonOutputWriterTestHelper {
         });
     }
 
+    @Test
+    void plainJsonValues() throws IOException {
+        sut = new JsonOutputWriter(byteStream);
+
+        final Struct struct1 = new Struct(level1Schema).put("name", "John");
+        final Struct struct2 = new Struct(level1Schema).put("name", "Pekka");
+
+        final SinkRecord record1 = createRecord("key0", level1Schema, struct1, 1, 1000L);
+        final SinkRecord record2 = createRecord("key0", level1Schema, struct2, 1, 1000L);
+
+        assertRecords(List.of(record1, record2), "[{\"name\":\"John\"},{\"name\":\"Pekka\"}]");
+    }
+
     @Override
     String parseJson(final byte[] json) throws IOException {
         return objectMapper.readTree(json).toString();


### PR DESCRIPTION
I am facing a similar problem that is described in here https://github.com/aiven/aiven-kafka-connect-gcs/issues/81 
Therefore, I am adding 2 new json writers that would allow to write plain json values without wrapping them in envelopes.